### PR TITLE
Various changes so I can package this

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *.la
 *.dirstamp
+*.pc
 TAGS
 tags
 core*
@@ -10,6 +11,7 @@ core*
 # C autoconf crap
 autom4te.cache
 *.in
+!/src/libbase64-1.pc.in
 config.*
 compile
 *.m4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o
+*.lo
 *.a
+*.la
 *.dirstamp
 TAGS
 tags
@@ -22,6 +24,9 @@ install-sh
 missing
 Makefile
 .deps
+.libs
+libtool
+ltmain.sh
 
 # texinfo out
 doc/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.a
+*.dirstamp
 TAGS
 tags
 core*
@@ -27,4 +28,8 @@ doc/*.pdf
 doc/*.info
 doc/*.log
 
+/test-driver
+/test-suite.log
 tests/base64_test
+tests/base64_test.log
+tests/base64_test.trs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ addons:
     - autoconf
     - libtool
     - libcunit1-dev
+    - pkg-config
 script: autoreconf -i && ./configure && make && make check
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS = -Im4
 SUBDIRS := doc src tests
 
 TESTS := tests/base64_test

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT([libbase64],
          [kyle@tyrfingr.is],
          [],
          [https://github.com/kisom/libbase64])
-AM_INIT_AUTOMAKE([1.11 foreign])
+AM_INIT_AUTOMAKE([1.11 foreign subdir-objects])
 
 AC_CONFIG_SRCDIR([src/base64.h])
 AC_CONFIG_FILES([Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,9 @@ AC_INIT([libbase64],
          [https://github.com/kisom/libbase64])
 AM_INIT_AUTOMAKE([1.11 foreign subdir-objects])
 
+LT_INIT
+AC_CONFIG_MACRO_DIR([m4])
+
 AC_CONFIG_SRCDIR([src/base64.h])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
@@ -14,6 +17,5 @@ AC_CONFIG_FILES([Makefile
 
 AC_PROG_CC
 AC_PROG_INSTALL
-AC_PROG_RANLIB
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -9,9 +9,12 @@ AM_INIT_AUTOMAKE([1.11 foreign subdir-objects])
 LT_INIT
 AC_CONFIG_MACRO_DIR([m4])
 
+PKG_PROG_PKG_CONFIG
+
 AC_CONFIG_SRCDIR([src/base64.h])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
+                 src/libbase64-1.pc
                  tests/Makefile
                  doc/Makefile])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,7 @@
+ACLOCAL_AMFLAGS = -Im4
 AM_CFLAGS = -Werror -Wall -std=c99 -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE
 
-lib_LIBRARIES = libbase64.a
-libbase64_a_SOURCES = base64.c
+lib_LTLIBRARIES = libbase64.la
+libbase64_la_SOURCES = base64.c
+libbase64_la_LDFLAGS = -version-info 0:0:0
 include_HEADERS = base64.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -Werror -Wall -std=c99 -D_XOPEN_SOURCE=700 -D_BSD_SOURCE
+AM_CFLAGS = -Werror -Wall -std=c99 -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE
 
 lib_LIBRARIES = libbase64.a
 libbase64_a_SOURCES = base64.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,3 +5,6 @@ lib_LTLIBRARIES = libbase64.la
 libbase64_la_SOURCES = base64.c
 libbase64_la_LDFLAGS = -version-info 0:0:0
 include_HEADERS = base64.h
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libbase64-1.pc

--- a/src/base64.h
+++ b/src/base64.h
@@ -50,6 +50,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int              base64_encode(const uint8_t *, size_t, char *, size_t);
 int              base64_decode(const char *, uint8_t*, size_t);
@@ -57,5 +60,8 @@ size_t           base64_enclen(size_t);
 size_t           base64_declen(size_t);
 const char      *base64_lib_version(void);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/src/libbase64-1.pc.in
+++ b/src/libbase64-1.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: OpenBSD base64 functions
+URL: @PACKAGE_URL@
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -Wl,-rpath,${libdir} -lbase64

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -I/usr/local/include -I../src
-AM_CFLAGS += -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -Werror -Wall
+AM_CFLAGS += -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE -Werror -Wall
 AM_LDFLAGS = -L/usr/local/lib
 
 check_PROGRAMS = base64_test


### PR DESCRIPTION
I had some other base64 handling code in one of my projects that I was going to pull out into a library for my own use, but a quick Google result suggested using your library instead.  This pull request contains a few patches that I'd like to have before I use it myself.  The patches are all small things, so it's not really a coherent pull request.

While there's comments in each commit, this pull request does the following things:
- Patches 1 and 2 make libbase64 build cleanly on my machine.
- Patch 3 adds stuff to .gitignore, so my "git status" is clean
- Patch 4 build shared libraries (instead of static libraries)
- Patch 5 installs a pkg-config script, so users of libbase64 can find it without resorting to autoconf hacks.
- Patch 6 allows libbase64 to be linked by C++ programs a bit more cleanly.

Additionally, I'd like to request that you tag a stable version of libbase64 (with "git tag -s v1.0.0") so github will make a named tarball available -- this way I'll be able to point my favorite distro's package scripts to that tarball.

Thanks for doing all the work to pull this out into a nice clean library!
